### PR TITLE
Chani auto walk

### DIFF
--- a/modules/Action.lua
+++ b/modules/Action.lua
@@ -326,6 +326,12 @@ function Action.troops(color, from, to, baseCount)
     Types.assertIsInteger(baseCount)
     local count = Park.transfert(baseCount, Action.getTroopPark(color, from), Action.getTroopPark(color, to))
 
+    -- bloodlines Chani passive: track retreats / losses from combat
+    -- If troops leave the combat (from == 'combat') and actually moved (count > 0), emit event
+    if from == 'combat' and count > 0 then
+        Helper.emitEvent('troopRetreatedFromCombat', color, count, to)
+    end
+
     if not Action.troopTransferCoalescentQueue then
 
         local function coalesce(t1, t2)

--- a/modules/Combat.lua
+++ b/modules/Combat.lua
@@ -103,6 +103,18 @@ function Combat._transientSetUp(settings)
             TurnControl.overridePhaseTurnSequence(turnSequence)
             Combat.showRanking(turnSequence, Combat.ranking)
         elseif phase == "recall" then
+                -- bloodlines: emit event with remaining troop counts in combat before they are recalled (supports Chani passive)
+                local troopCounts = {}
+                for _, object in ipairs(Combat.combatCenterZone.getObjects()) do
+                    for _, color in ipairs(PlayBoard.getActivePlayBoardColors()) do
+                        if Types.isTroop(object, color) then
+                            troopCounts[color] = (troopCounts[color] or 0) + 1
+                        end
+                    end
+                end
+                for color, count in pairs(troopCounts) do
+                    Helper.emitEvent("troopsRemovedFromCombatAtRecall", color, count)
+                end
             for _, object in ipairs(Combat.rewardTokenZone.getObjects()) do
                 if Types.isVictoryPointToken(object) or Types.isObjectiveToken(object) then
                     MainBoard.trash(object)

--- a/modules/en/Locale.lua
+++ b/modules/en/Locale.lua
@@ -463,6 +463,8 @@ return {
     piterTwistedGenius = "↯ Piter De Vries is a twisted genius!",
     lietHatesTheMaker = "↯ Liet Kynes hates the Maker! Gets 1 trash, 1 spice and 1 intrigue.",
     lietHatesTheMakerDeepDesert = "↯ Liet Kynes really hates the Maker! Gets 2 trash, 2 spice and 2 intrigue.",
+    chaniTacticianSpice = "↯ Chani gains 1 spice (Tactician).",
+    chaniTacticianWater = "↯ Chani gains 1 water (Tactician).",
 
     -- Uprising leaders
     stabanTuek = "Staban Tuek",

--- a/modules/fr/Locale.lua
+++ b/modules/fr/Locale.lua
@@ -407,6 +407,8 @@ return {
     firstSnooperRecallEffectInfo = "Ayant rappelé votre premier fouineur, vous pouvez défausser une carte pour gagne 1 mesure d’épice.",
     finalDeliveryTooltip = "Dernière livraison.",
     gurneySmile = "↯ Gurney montre ses dents.",
+    chaniTacticianSpice = "↯ Chani gagne 1 unité d'épice (Tacticienne).",
+    chaniTacticianWater = "↯ Chani gagne 1 mesure d'eau (Tacticienne).",
     imperialBirthright = "↯ Irulan exerce son droit de naissance.",
     loyalty = "↯ Margot récolte les fruits de sa loyauté",
     stabanSpiceSmuggling = "↯ Staban détourne sa part d’épice.",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chani bloodline passive automated: training marker advances when troops leave combat, grants rewards automatically, and preserves per-faction progress.
  * Added in-game notifications when troops retreat from combat.
  * During recall, the game reports per-faction troop counts leaving combat for clearer resolution feedback.
  * Added English and French locale entries for Chani’s reward messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->